### PR TITLE
GitHub Actionsの環境変数設定方法変更

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         rm neko-${NEKO_VERSION}-linux64.tar.gz
         mv neko-${NEKO_VERSION}-linux64 $HOME/neko
         echo "$HOME/neko" >> $GITHUB_PATH
-        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH:$HOME/neko"
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/neko" >> $GITHUB_ENV
       env:
         NEKO_VERSION: 2.3.0
     - name: Install Haxe
@@ -24,7 +24,7 @@ jobs:
         rm haxe-${HAXE_VERSION}-linux64.tar.gz
         mv haxe $HOME/haxe
         echo "$HOME/haxe" >> $GITHUB_PATH
-        echo "::set-env name=HAXE_STD_PATH::$HOME/haxe/std"
+        echo "HAXE_STD_PATH=$HOME/haxe/std" >> $GITHUB_ENV
       env:
         HAXE_VERSION: 4.1.4
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         tar xzvf neko-${NEKO_VERSION}-linux64.tar.gz
         rm neko-${NEKO_VERSION}-linux64.tar.gz
         mv neko-${NEKO_VERSION}-linux64 $HOME/neko
-        echo "::add-path::$HOME/neko"
+        echo "$HOME/neko" >> $GITHUB_PATH
         echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH:$HOME/neko"
       env:
         NEKO_VERSION: 2.3.0
@@ -23,7 +23,7 @@ jobs:
         mkdir haxe && tar xzvf haxe-${HAXE_VERSION}-linux64.tar.gz -C haxe --strip-components 1
         rm haxe-${HAXE_VERSION}-linux64.tar.gz
         mv haxe $HOME/haxe
-        echo "::add-path::$HOME/haxe"
+        echo "$HOME/haxe" >> $GITHUB_PATH
         echo "::set-env name=HAXE_STD_PATH::$HOME/haxe/std"
       env:
         HAXE_VERSION: 4.1.4


### PR DESCRIPTION
## WHY

`set-env`, `add-path` が脆弱性につき非推奨（エラー出力して終了）になった。

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## WHAT

- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
- https://qiita.com/shonansurvivors/items/f256a0443d346f09448e

上記を参考に以下のように修正

- `add-path`は`$GITHUB_PATH`に追記する形式
- `set-env`は`$GITHUB_ENV`に追記する形式